### PR TITLE
Strava now returns a dictionary object instead of a string token

### DIFF
--- a/monolith/views/auth.py
+++ b/monolith/views/auth.py
@@ -19,7 +19,7 @@ def _strava_auth():
     access_token = xc(client_id=auth.app.config['STRAVA_CLIENT_ID'],
                       client_secret=auth.app.config['STRAVA_CLIENT_SECRET'],
                       code=code)
-    current_user.strava_token = access_token
+    current_user.strava_token = access_token['access_token']
     db.session.add(current_user)
     db.session.commit()
     return redirect('/')


### PR DESCRIPTION
Strava is now returning a dictionary of the form:
{'access_token': 'xxx', 'refresh_token': 'yyy', 'expires_at': ddd}