### PR TITLE
Hash password before save

### DIFF
--- a/monolith/views/users.py
+++ b/monolith/views/users.py
@@ -22,6 +22,7 @@ def create_user():
         if form.validate_on_submit():
             new_user = User()
             form.populate_obj(new_user)
+            new_user.set_password(new_user.password)
             db.session.add(new_user)
             db.session.commit()
             return redirect('/users')


### PR DESCRIPTION
As it is, the password is saved without hashing and when logging in, the form password is compared with the password hash that was never saved, thus failing to login.